### PR TITLE
Updated the iOS native SDK version, mpLib, libVersion and podspec

### DIFF
--- a/MixpanelReactNativeSessionReplay.podspec
+++ b/MixpanelReactNativeSessionReplay.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
 
   s.source_files = "ios/**/*.{h,m,mm,cpp,swift}"
   s.private_header_files = "ios/**/*.h"
-  s.dependency 'MixpanelSessionReplay', '~> 1.1.2'
+  s.dependency 'MixpanelSessionReplay', '1.1.3'
 # Use install_modules_dependencies helper to install the dependencies if React Native version >=0.71.0.
 # See https://github.com/facebook/react-native/blob/febf6b7f33fdb4904669f99d795eba4c0f95d7bf/scripts/cocoapods/new_architecture.rb#L79.
 if respond_to?(:install_modules_dependencies, true)

--- a/ios/MixpanelSwiftSessionReplay.swift
+++ b/ios/MixpanelSwiftSessionReplay.swift
@@ -3,7 +3,9 @@ import UIKit
 import MixpanelSessionReplay
 
 @objc public class MixpanelSwiftSessionReplay: NSObject {
-
+  static let libVersion = "0.1.1"
+  static let mpLib = "react-native-sr"
+  
   @objc public static func startRecording() {
     MPSessionReplay.getInstance()?.startRecording()
   }
@@ -24,6 +26,8 @@ import MixpanelSessionReplay
     }
     
     do {
+      APIConstants.setLibVersion(libVersion)
+      APIConstants.setMpLib(mpLib)
       let config = try MPSessionReplayConfig.from(json: data)
       MPSessionReplay.initialize(token: token, distinctId: distinctId, config: config) { result in
         switch result {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mixpanel-react-native-session-replay",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Official React Native turbo module for Mixpanel Session Replay",
   "private": true,
   "main": "./lib/module/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mixpanel-react-native-session-replay",
-  "version": "0.1.1",
+  "version": "0.1.0",
   "description": "Official React Native turbo module for Mixpanel Session Replay",
   "private": true,
   "main": "./lib/module/index.js",


### PR DESCRIPTION
- Updated podspec to use native iOS SDK version to `1.1.3` that supports overriding the mpLib and libVersion values
- Updated the mpLib and libVersion values from the plugin's iOS code
- Updated package.json file with version `0.1.1`