### PR TITLE
[SR-120] feat: update native mp lib and lib version from React Native plugin for Android

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -79,7 +79,7 @@ dependencies {
   implementation "com.mixpanel.android:mixpanel-android:8.0.2"
   
   // Mixpanel Android Session Replay SDK dependency
-  implementation "com.mixpanel.android:mixpanel-android-session-replay:1.0.0"
+  implementation "com.mixpanel.android:mixpanel-android-session-replay:1.0.2"
 }
 
 react {

--- a/android/src/main/java/com/mixpanelreactnativesessionreplay/MixpanelReactNativeSessionReplayModule.kt
+++ b/android/src/main/java/com/mixpanelreactnativesessionreplay/MixpanelReactNativeSessionReplayModule.kt
@@ -8,6 +8,7 @@ import com.mixpanel.android.sessionreplay.MPSessionReplayInstance
 import com.mixpanel.android.sessionreplay.MPSessionReplayError
 import com.mixpanel.android.sessionreplay.models.MPSessionReplayConfig
 import com.mixpanel.android.sessionreplay.sensitive_views.AutoMaskedView
+import com.mixpanel.android.sessionreplay.utils.APIConstants
 import org.json.JSONObject
 import org.json.JSONArray
 
@@ -48,6 +49,10 @@ class MixpanelReactNativeSessionReplayModule(reactContext: ReactApplicationConte
         return
       }
       println("Mixpanel - Config variable fromJson: $replayConfig")
+
+      // Set library version and name
+      APIConstants.setLibVersion(LIB_VERSION)
+      APIConstants.setMpLib(MP_LIB)
 
       // Initialize Mixpanel Session Replay
       MPSessionReplay.initialize(
@@ -277,5 +282,7 @@ class MixpanelReactNativeSessionReplayModule(reactContext: ReactApplicationConte
 
   companion object {
     const val NAME = "MixpanelReactNativeSessionReplay"
+    const val LIB_VERSION = "0.1.1"
+    const val MP_LIB = "react-native-sr"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mixpanel-react-native-session-replay",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Official React Native turbo module for Mixpanel Session Replay",
   "private": true,
   "main": "./lib/module/index.js",


### PR DESCRIPTION
This commit updates the Mixpanel Android Session Replay SDK to version 1.0.2. Additionally, it sets the library version to "0.1.1" and the mpLib identifier to "react-native-sr" for Android. The overall package version is also bumped to "0.1.1".