### PR TITLE
chore: remove unused mixpanel-android dependency

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -74,7 +74,6 @@ def kotlin_version = getExtOrDefault("kotlinVersion")
 dependencies {
   implementation "com.facebook.react:react-android"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-  
 
   // Mixpanel Android Session Replay SDK dependency
   implementation "com.mixpanel.android:mixpanel-android-session-replay:1.0.4"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -75,9 +75,7 @@ dependencies {
   implementation "com.facebook.react:react-android"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
   
-  // Mixpanel Android SDK dependency (minimum v8.0.2)
-  implementation "com.mixpanel.android:mixpanel-android:8.0.2"
-  
+
   // Mixpanel Android Session Replay SDK dependency
   implementation "com.mixpanel.android:mixpanel-android-session-replay:1.0.4"
 }


### PR DESCRIPTION
This pull request makes a minor update to the Android build configuration by removing the direct dependency on the main Mixpanel Android SDK. The Mixpanel Android Session Replay SDK dependency remains.

- Removed the `mixpanel-android` SDK version 8.0.2 from the dependencies in `android/build.gradle`.