### PR TITLE
Bumped version to 1.2.0

### DIFF
--- a/android/src/main/java/com/mixpanelreactnativesessionreplay/MixpanelReactNativeSessionReplayModule.kt
+++ b/android/src/main/java/com/mixpanelreactnativesessionreplay/MixpanelReactNativeSessionReplayModule.kt
@@ -307,7 +307,7 @@ class MixpanelReactNativeSessionReplayModule(reactContext: ReactApplicationConte
 
   companion object {
     const val NAME = "MixpanelReactNativeSessionReplay"
-    const val LIB_VERSION = "1.1.0"
+    const val LIB_VERSION = "1.2.0"
     const val MP_LIB = "react-native-sr"
   }
 }

--- a/ios/MixpanelSwiftSessionReplay.swift
+++ b/ios/MixpanelSwiftSessionReplay.swift
@@ -3,7 +3,7 @@ import MixpanelSessionReplay
 import UIKit
 
 @objc public class MixpanelSwiftSessionReplay: NSObject {
-  static let libVersion = "1.1.0"
+  static let libVersion = "1.2.0"
   static let mpLib = "react-native-sr"
 
   @objc public static func startRecording(recordingSessionsPercent: Double = 100.0) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mixpanel/react-native-session-replay",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Official React Native turbo module for Mixpanel Session Replay",
   "main": "./lib/module/index.js",
   "types": "./lib/typescript/src/index.d.ts",


### PR DESCRIPTION
I am trying to release react native with 1.1.0 for the remote settings changes. The current version is 1.0.1 .
I am hitting an npm error (E400) as below.
```
npm error code E400
npm error 400 Bad Request - PUT https://registry.npmjs.org/@mixpanel%2freact-native-session-replay - Cannot publish over previously published version "1.1.0".
```
npm error A complete log of this run can be found in: /Users/ketan/.npm/_logs/2026-03-27T13_12_42_409Z-debug-0.logIt looks like version 1.1.0 was published and unpublished back in January. NPM policy prevents reusing "burned" version numbers for security.
```
ketan@G4JY03V6LC-ketanshikhare mixpanel-react-native-session-replay % npm view @mixpanel/react-native-session-replay time

{
  created: '2025-10-08T22:24:59.535Z',
  modified: '2026-02-03T18:48:26.705Z',
  '0.1.2': '2025-10-08T22:24:59.876Z',
  '0.1.3': '2025-10-10T18:32:27.590Z',
  '0.2.0': '2025-10-21T17:10:31.493Z',
  '0.3.0': '2025-12-11T23:16:31.439Z',
  '1.1.0': '2026-01-14T20:08:40.288Z',
  '1.0.0': '2026-01-14T20:16:04.825Z',
  '1.0.1': '2026-01-28T02:56:57.920Z'
}
```
So to keep our version history clean, I am jumping to 1.2.0 instead of 1.1.1.