### PR TITLE
[DEV-355] chore: add min-release-age to .npmrc to prevent supply chain attacks

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+# Prevent supply chain attacks
+min-release-age=7


### PR DESCRIPTION
Adds `min-release-age=7` to the root `.npmrc`. This prevents npm from installing packages that were published less than 7 days ago, which is an effective mitigation against supply chain attacks where attackers publish malicious packages and immediately push them downstream.