### PR TITLE
feat: add data residency / custom server URL support

### DIFF
--- a/MixpanelReactNativeSessionReplay.podspec
+++ b/MixpanelReactNativeSessionReplay.podspec
@@ -15,10 +15,7 @@ Pod::Spec.new do |s|
 
   s.source_files = "ios/**/*.{h,m,mm,cpp,swift}"
   s.private_header_files = "ios/**/*.h"
-  # TODO: bump MixpanelSessionReplay once the release containing data residency
-  # support (https://github.com/mixpanel/mixpanel-ios-session-replay-package/pull/36)
-  # is published — `serverURL` in MPSessionReplayConfig is silently ignored until then.
-  s.dependency 'MixpanelSessionReplay', '1.5.0'
+  s.dependency 'MixpanelSessionReplay', '1.5.1'
 # Use install_modules_dependencies helper to install the dependencies if React Native version >=0.71.0.
 # See https://github.com/facebook/react-native/blob/febf6b7f33fdb4904669f99d795eba4c0f95d7bf/scripts/cocoapods/new_architecture.rb#L79.
 if respond_to?(:install_modules_dependencies, true)

--- a/MixpanelReactNativeSessionReplay.podspec
+++ b/MixpanelReactNativeSessionReplay.podspec
@@ -15,6 +15,9 @@ Pod::Spec.new do |s|
 
   s.source_files = "ios/**/*.{h,m,mm,cpp,swift}"
   s.private_header_files = "ios/**/*.h"
+  # TODO: bump MixpanelSessionReplay once the release containing data residency
+  # support (https://github.com/mixpanel/mixpanel-ios-session-replay-package/pull/36)
+  # is published — `serverURL` in MPSessionReplayConfig is silently ignored until then.
   s.dependency 'MixpanelSessionReplay', '1.5.0'
 # Use install_modules_dependencies helper to install the dependencies if React Native version >=0.71.0.
 # See https://github.com/facebook/react-native/blob/febf6b7f33fdb4904669f99d795eba4c0f95d7bf/scripts/cocoapods/new_architecture.rb#L79.

--- a/src/__tests__/index.test.tsx
+++ b/src/__tests__/index.test.tsx
@@ -1,4 +1,5 @@
 import {
+  MPDataResidency,
   MPDebugOptions,
   MPDebugOverlayColors,
   MPSessionReplay,
@@ -192,6 +193,7 @@ describe('MPSessionReplayConfig', () => {
     expect(config.remoteSettingsMode).toBe(
       MPSessionReplayRemoteSettingsMode.Disabled
     );
+    expect(config.serverURL).toBe(MPDataResidency.US);
   });
 
   it('should accept custom values', () => {
@@ -203,6 +205,7 @@ describe('MPSessionReplayConfig', () => {
       flushInterval: 20,
       enableLogging: true,
       remoteSettingsMode: MPSessionReplayRemoteSettingsMode.Strict,
+      serverURL: MPDataResidency.EU,
     });
 
     expect(config.wifiOnly).toBe(false);
@@ -214,6 +217,15 @@ describe('MPSessionReplayConfig', () => {
     expect(config.remoteSettingsMode).toBe(
       MPSessionReplayRemoteSettingsMode.Strict
     );
+    expect(config.serverURL).toBe('https://api-eu.mixpanel.com');
+  });
+
+  it('should accept a custom serverURL string', () => {
+    const config = new MPSessionReplayConfig({
+      serverURL: 'https://mixpanel-proxy.test',
+    });
+
+    expect(config.serverURL).toBe('https://mixpanel-proxy.test');
   });
 
   it('should serialize to JSON string', () => {
@@ -332,6 +344,62 @@ describe('MPSessionReplayConfig', () => {
       const parsed = JSON.parse(json);
 
       expect(parsed).not.toHaveProperty('enableSessionReplayOniOS26AndLater');
+    });
+
+    it('should serialize serverURL as `serverUrl` for Android', () => {
+      jest.doMock('react-native', () => ({
+        Platform: {
+          OS: 'android',
+          select: (obj: any) => obj.android ?? obj.default,
+        },
+        requireNativeComponent: jest.fn(() => 'MockedNativeComponent'),
+      }));
+
+      const {
+        MPSessionReplayConfig: AndroidConfig,
+        MPDataResidency: AndroidDataResidency,
+      } = require('../index');
+
+      let config = new AndroidConfig();
+      let parsed = JSON.parse(config.toJSON());
+      expect(parsed.serverUrl).toBe('https://api.mixpanel.com');
+      expect(parsed).not.toHaveProperty('serverURL');
+
+      config = new AndroidConfig({ serverURL: AndroidDataResidency.EU });
+      parsed = JSON.parse(config.toJSON());
+      expect(parsed.serverUrl).toBe('https://api-eu.mixpanel.com');
+
+      config = new AndroidConfig({ serverURL: 'https://mixpanel-proxy.test' });
+      parsed = JSON.parse(config.toJSON());
+      expect(parsed.serverUrl).toBe('https://mixpanel-proxy.test');
+    });
+
+    it('should serialize serverURL as `serverURL` for iOS', () => {
+      jest.doMock('react-native', () => ({
+        Platform: {
+          OS: 'ios',
+          select: (obj: any) => obj.ios ?? obj.default,
+        },
+        requireNativeComponent: jest.fn(() => 'MockedNativeComponent'),
+      }));
+
+      const {
+        MPSessionReplayConfig: IOSConfig,
+        MPDataResidency: IOSDataResidency,
+      } = require('../index');
+
+      let config = new IOSConfig();
+      let parsed = JSON.parse(config.toJSON());
+      expect(parsed.serverURL).toBe('https://api.mixpanel.com');
+      expect(parsed).not.toHaveProperty('serverUrl');
+
+      config = new IOSConfig({ serverURL: IOSDataResidency.IN });
+      parsed = JSON.parse(config.toJSON());
+      expect(parsed.serverURL).toBe('https://api-in.mixpanel.com');
+
+      config = new IOSConfig({ serverURL: 'https://mixpanel-proxy.test' });
+      parsed = JSON.parse(config.toJSON());
+      expect(parsed.serverURL).toBe('https://mixpanel-proxy.test');
     });
 
     it('should return empty string for unsupported platforms', () => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -21,14 +21,14 @@ export enum MPSessionReplayRemoteSettingsMode {
  * session replay traffic to the matching region, or pass any other `https://` URL
  * to send traffic through a custom endpoint (for example, a corporate proxy).
  */
-export const MPDataResidency = {
+export const MPDataResidency: Readonly<Record<'US' | 'EU' | 'IN', string>> = {
   /** US data residency (default): `https://api.mixpanel.com`. */
   US: 'https://api.mixpanel.com',
   /** EU data residency: `https://api-eu.mixpanel.com`. */
   EU: 'https://api-eu.mixpanel.com',
   /** India data residency: `https://api-in.mixpanel.com`. */
   IN: 'https://api-in.mixpanel.com',
-} as const;
+};
 
 /**
  * Color configuration for the on-device debug mask overlay.
@@ -267,9 +267,9 @@ export class MPSessionReplayConfig {
    * fully-qualified `https://` URL to route traffic through a custom endpoint such
    * as a corporate proxy.
    *
-   * The URL must use `https://` and must not contain a path. The underlying native
-   * SDKs validate the URL during `initialize` — invalid URLs cause initialization
-   * to fail (Android) or be logged as an error (iOS).
+   * The URL must use `https://`. The underlying native SDKs validate the URL
+   * during `initialize` — invalid URLs cause `initialize` to reject with an error
+   * on both platforms.
    *
    * - **Default:** `MPDataResidency.US` (`https://api.mixpanel.com`)
    */
@@ -289,7 +289,7 @@ export class MPSessionReplayConfig {
     enableLogging = false,
     remoteSettingsMode = MPSessionReplayRemoteSettingsMode.Disabled,
     debugOptions = null,
-    serverURL = MPDataResidency.US as string,
+    serverURL = MPDataResidency.US,
   }: Partial<MPSessionReplayConfig> = {}) {
     this.wifiOnly = wifiOnly;
     this.autoStartRecording = autoStartRecording;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -15,6 +15,22 @@ export enum MPSessionReplayRemoteSettingsMode {
 }
 
 /**
+ * Base URLs for Mixpanel's managed data residency regions.
+ *
+ * Pass one of these constants to {@link MPSessionReplayConfig.serverURL} to route
+ * session replay traffic to the matching region, or pass any other `https://` URL
+ * to send traffic through a custom endpoint (for example, a corporate proxy).
+ */
+export const MPDataResidency = {
+  /** US data residency (default): `https://api.mixpanel.com`. */
+  US: 'https://api.mixpanel.com',
+  /** EU data residency: `https://api-eu.mixpanel.com`. */
+  EU: 'https://api-eu.mixpanel.com',
+  /** India data residency: `https://api-in.mixpanel.com`. */
+  IN: 'https://api-in.mixpanel.com',
+} as const;
+
+/**
  * Color configuration for the on-device debug mask overlay.
  *
  * Each color accepts any React Native [`ColorValue`](https://reactnative.dev/docs/colors)
@@ -243,6 +259,22 @@ export class MPSessionReplayConfig {
    */
   debugOptions: MPDebugOptions | null;
 
+  /**
+   * Base URL used to send session replay data to Mixpanel.
+   *
+   * Use one of the {@link MPDataResidency} constants to target a managed region
+   * (`MPDataResidency.US`, `MPDataResidency.EU`, `MPDataResidency.IN`), or pass any
+   * fully-qualified `https://` URL to route traffic through a custom endpoint such
+   * as a corporate proxy.
+   *
+   * The URL must use `https://` and must not contain a path. The underlying native
+   * SDKs validate the URL during `initialize` — invalid URLs cause initialization
+   * to fail (Android) or be logged as an error (iOS).
+   *
+   * - **Default:** `MPDataResidency.US` (`https://api.mixpanel.com`)
+   */
+  serverURL: string;
+
   constructor({
     wifiOnly = true,
     autoStartRecording = true,
@@ -257,6 +289,7 @@ export class MPSessionReplayConfig {
     enableLogging = false,
     remoteSettingsMode = MPSessionReplayRemoteSettingsMode.Disabled,
     debugOptions = null,
+    serverURL = MPDataResidency.US as string,
   }: Partial<MPSessionReplayConfig> = {}) {
     this.wifiOnly = wifiOnly;
     this.autoStartRecording = autoStartRecording;
@@ -266,6 +299,7 @@ export class MPSessionReplayConfig {
     this.enableLogging = enableLogging;
     this.remoteSettingsMode = remoteSettingsMode;
     this.debugOptions = debugOptions;
+    this.serverURL = serverURL;
   }
 
   private transformMaskValueForPlatform(value: string): string {
@@ -299,9 +333,14 @@ export class MPSessionReplayConfig {
       enableLogging: this.enableLogging,
       remoteSettingsMode: transformedRemoteSettingsMode,
       debugOptions: serializeDebugOptions(this.debugOptions),
-      // iOS-specific config to enable session replay on iOS 26 and later
+      // The native SDKs spell the server URL field differently — Android's
+      // kotlinx.serialization expects `serverUrl`, iOS's Codable expects `serverURL`.
       ...Platform.select({
-        ios: { enableSessionReplayOniOS26AndLater: true },
+        ios: {
+          enableSessionReplayOniOS26AndLater: true,
+          serverURL: this.serverURL,
+        },
+        android: { serverUrl: this.serverURL },
         default: {},
       }),
     };


### PR DESCRIPTION
## Summary

- Adds `MPDataResidency` constants (`US`, `EU`, `IN`) and a `serverURL` field on `MPSessionReplayConfig`, so apps can route session replay traffic to a managed region or a custom https endpoint
- `toJSON()` emits `serverUrl` for Android (matches kotlinx.serialization on the data class) and `serverURL` for iOS (matches Swift Codable on the struct) — the native field names diverge, but the value goes through unchanged
- URL validation stays entirely on the native side; both SDKs reject bad URLs and propagate the error back through the existing promise rejection path

## Usage

```ts
import {
  MPSessionReplay,
  MPSessionReplayConfig,
  MPDataResidency,
} from '@mixpanel/react-native-session-replay';

// Managed region
const config = new MPSessionReplayConfig({ serverURL: MPDataResidency.EU });

// Custom endpoint (e.g. corporate proxy)
const config2 = new MPSessionReplayConfig({
  serverURL: 'https://my-proxy.example',
});
```

## Native SDK requirements

- **Android**: requires `mixpanel-android-session-replay` 1.4.0, which contains https://github.com/mixpanel/mixpanel-android-session-replay/pull/145. Pinned in `android/build.gradle`.
- **iOS**: requires `MixpanelSessionReplay` 1.5.1, which contains https://github.com/mixpanel/mixpanel-ios-session-replay-package/pull/36. Pinned in `MixpanelReactNativeSessionReplay.podspec`.

## Test plan

- [x] `yarn typecheck`
- [x] `yarn lint`
- [x] `yarn test` (34/34 passing, includes new platform-specific serialization assertions for `serverUrl` vs `serverURL`)
- [ ] Smoke-test Android example app with `MPDataResidency.EU` and a bad URL — confirm reject path
- [ ] Smoke-test iOS example app with `MPDataResidency.EU` and a bad URL — confirm reject path

🤖 Generated with [Claude Code](https://claude.com/claude-code)